### PR TITLE
Replace deprecated action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.7'
+      uses: ruby/setup-ruby@v1
     - name: Set up cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.7'
+      uses: ruby/setup-ruby@v1
     - name: Setup Rubygems
       env:
         RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
The action `actions/setup-ruby` has been deprecated. The action `ruby/setup-ruby` is recommended instead.

The new action reads the ruby version automatically from `.ruby-version`.