### PR TITLE
Replace deprecated action

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
+        uses: ruby/setup-ruby@v1
       - name: Set up cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
`actions/setup-ruby` has been deprecated. `ruby/setup-ruby` is recommended instead.

We've already replaced it in `build` and `publish` workflows, but forgot about `smoke_test`.